### PR TITLE
chore: update security workflow to use commit hash for actions/checkout

### DIFF
--- a/.github/workflows/security-review.yml
+++ b/.github/workflows/security-review.yml
@@ -1,0 +1,22 @@
+name: Security Review
+
+permissions:
+  pull-requests: write  # Needed for leaving PR comments
+  contents: read
+
+on:
+  pull_request:
+
+jobs:
+  security:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@ff7abcd0c3c05ccf6adc123a8cd1fd4fb30fb493
+        with:
+          ref: ${{ github.event.pull_request.head.sha || github.sha }}
+          fetch-depth: 2
+
+      - uses: anthropics/claude-code-security-review@c51ac4fce843683a8c6ba9e63bc47efcbce3da30
+        with:
+          comment-pr: true
+          claude-api-key: ${{ secrets.CLAUDE_API_KEY }}


### PR DESCRIPTION
- Replace actions/checkout@v4 with specific commit hash for better security
- Pin to commit ff7abcd0c3c05ccf6adc123a8cd1fd4fb30fb493 for reproducible builds

🤖 Generated with [Claude Code](https://claude.ai/code)