### PR TITLE
ci: add golden path smoke tests to build-pr workflow

### DIFF
--- a/.github/workflows/build-pr.yml
+++ b/.github/workflows/build-pr.yml
@@ -13,21 +13,43 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       -
-        name: Set up QEMU
-        uses: docker/setup-qemu-action@ce360397dd3f832beb865e1373c09c0e9f86d70a # tag=v4.0.0
+        name: Checkout
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # tag=v3.0.0
       -
         name: Set up Docker Buildx
         uses: docker/setup-buildx-action@4d04d5d9486b7bd6fa91e7baf45bbb4f8b9deedd # tag=v4.0.0
       -
-#        name: Login to DockerHub
-#        uses: docker/login-action@v2
-#        with:
-#          username: ${{ secrets.DOCKERHUB_USERNAME }}
-#          password: ${{ secrets.DOCKERHUB_TOKEN }}
-#      -
-        name: Build and push
+        name: Build
         uses: docker/build-push-action@d08e5c354a6adb9ed34480a06d141179aa583294 # tag=v1.1.1
         with:
           push: false
+          load: true
           tags: pointvy/pointvy:latest
           provenance: false             # temporary workaround, Cloud Run doesn't support multi-arch images
+      -
+        name: Run container
+        run: |
+          docker run -d --name pointvy -p 8080:8080 pointvy/pointvy:latest
+          for i in $(seq 1 15); do
+            curl -sf http://localhost:8080/ > /dev/null && echo "Container ready" && break
+            echo "Waiting for container... ($i/15)"
+            sleep 2
+          done
+      -
+        name: Test landing page
+        run: |
+          curl -sf http://localhost:8080/ | grep -qi "trivy"
+      -
+        name: Test scan (golden path)
+        run: |
+          result=$(curl -sf "http://localhost:8080/scan/?query=alpine:latest")
+          echo "$result" | grep -qi "alpine"
+      -
+        name: Verify non-root execution
+        run: |
+          uid=$(docker exec pointvy id -u)
+          [ "$uid" = "1001" ] || (echo "ERROR: container running as uid $uid, expected 1001" && exit 1)
+      -
+        name: Stop container
+        if: always()
+        run: docker stop pointvy && docker rm pointvy


### PR DESCRIPTION
After the image is built, load it into the local daemon, run it, and
verify the landing page, a real Trivy scan, and non-root execution before
reporting the PR check green.

Removes QEMU (incompatible with load: true) since single-arch is
sufficient for PR testing — multi-arch stays in build.yml and build-tag.yml.

https://claude.ai/code/session_01YKQTKvMMJV2af1CgpmMHAr